### PR TITLE
Bounding Box Conveniences

### DIFF
--- a/BentoMap.xcodeproj/project.pbxproj
+++ b/BentoMap.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		7237534E1D2DA0CF002A1BC2 /* QuadTree+SampleData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7237534D1D2DA0CF002A1BC2 /* QuadTree+SampleData.swift */; };
 		72383AB51D2ECAD00071EDE2 /* OptionalOr.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72383AB41D2ECAD00071EDE2 /* OptionalOr.swift */; };
 		72383AB71D2ECAF70071EDE2 /* OptionalOrTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72383AB61D2ECAF70071EDE2 /* OptionalOrTests.swift */; };
+		D4C3839B1D4F9DD500556EBE /* CollectionTypeExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C3839A1D4F9DD500556EBE /* CollectionTypeExtensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -86,6 +87,7 @@
 		7237534D1D2DA0CF002A1BC2 /* QuadTree+SampleData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "QuadTree+SampleData.swift"; sourceTree = "<group>"; };
 		72383AB41D2ECAD00071EDE2 /* OptionalOr.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptionalOr.swift; sourceTree = "<group>"; };
 		72383AB61D2ECAF70071EDE2 /* OptionalOrTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptionalOrTests.swift; sourceTree = "<group>"; };
+		D4C3839A1D4F9DD500556EBE /* CollectionTypeExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionTypeExtensions.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -141,6 +143,7 @@
 				723E206E1D2EBB9C00CF44FA /* Resources */,
 				7237531E1D2D9DA2002A1BC2 /* BoundingBox.swift */,
 				7237531F1D2D9DA2002A1BC2 /* Box.swift */,
+				D4C3839A1D4F9DD500556EBE /* CollectionTypeExtensions.swift */,
 				723753201D2D9DA2002A1BC2 /* OrdinalNodes.swift */,
 				723753221D2D9DA2002A1BC2 /* QuadTree.swift */,
 				723753231D2D9DA2002A1BC2 /* QuadTreeNode.swift */,
@@ -402,6 +405,7 @@
 				7237532A1D2D9DA2002A1BC2 /* QuadTreeNode.swift in Sources */,
 				7237532B1D2D9DA2002A1BC2 /* QuadTreeResult.swift in Sources */,
 				72383AB51D2ECAD00071EDE2 /* OptionalOr.swift in Sources */,
+				D4C3839B1D4F9DD500556EBE /* CollectionTypeExtensions.swift in Sources */,
 				723753251D2D9DA2002A1BC2 /* BoundingBox.swift in Sources */,
 				723753281D2D9DA2002A1BC2 /* QuadrantWrapper.swift in Sources */,
 				723753291D2D9DA2002A1BC2 /* QuadTree.swift in Sources */,

--- a/BentoMap/BoundingBox.swift
+++ b/BentoMap/BoundingBox.swift
@@ -10,6 +10,9 @@ import Foundation
 import MapKit
 
 public struct BoundingBox {
+
+    public static let world = BoundingBox(mapRect: MKMapRectWorld)
+
     public var mapRect: MKMapRect
 
     public init(minCoordinate: CLLocationCoordinate2D, maxCoordinate: CLLocationCoordinate2D) {
@@ -28,6 +31,7 @@ public struct BoundingBox {
     public init(mapRect: MKMapRect) {
         self.mapRect = mapRect
     }
+
 }
 
 public extension BoundingBox {
@@ -73,6 +77,7 @@ extension BoundingBox {
 }
 
 private extension MKMapRect {
+
     func divide(percent percent: Double, edge: CGRectEdge) -> (slice: MKMapRect, remainder: MKMapRect) {
         let amount: Double
         switch edge {
@@ -93,4 +98,5 @@ private extension MKMapRect {
         MKMapRectDivide(self, slice, remainder, amount, edge)
         return (slice: slice[0], remainder: remainder[0])
     }
+
 }

--- a/BentoMap/BoundingBox.swift
+++ b/BentoMap/BoundingBox.swift
@@ -10,7 +10,7 @@ import Foundation
 import MapKit
 
 public struct BoundingBox {
-    public let mapRect: MKMapRect
+    public var mapRect: MKMapRect
 
     public init(minCoordinate: CLLocationCoordinate2D, maxCoordinate: CLLocationCoordinate2D) {
         let minPoint = MKMapPointForCoordinate(minCoordinate)

--- a/BentoMap/Box.swift
+++ b/BentoMap/Box.swift
@@ -9,9 +9,11 @@
 import Foundation
 
 class Box<T> {
+
     var value: T
 
     init(value: T) {
         self.value = value
     }
+
 }

--- a/BentoMap/CollectionTypeExtensions.swift
+++ b/BentoMap/CollectionTypeExtensions.swift
@@ -1,0 +1,75 @@
+//
+//  CollectionTypeExtensions.swift
+//  BentoMap
+//
+//  Created by Rob Visentin on 8/1/16.
+//  Copyright © 2016 Raizlabs. All rights reserved.
+//
+
+import Foundation
+import MapKit
+
+public extension CollectionType where Generator.Element: MapPointProvider {
+
+    /// Computes the BoundingBox of the point cloud in O(n) time.
+    var boundingBox: BoundingBox {
+        guard let first = first else {
+            return BoundingBox(mapRect: MKMapRect())
+        }
+
+        var min = first.mapPoint
+        var max = first.mapPoint
+
+        for point in self {
+            let mapPoint = point.mapPoint
+
+            if mapPoint.x < min.x {
+                min.x = mapPoint.x
+            }
+            if mapPoint.x > mapPoint.x {
+                max.x = mapPoint.x
+            }
+            if mapPoint.y < min.y {
+                min.y = mapPoint.y
+            }
+            if mapPoint.y > max.y {
+                max.y = mapPoint.y
+            }
+        }
+
+        let rect = MKMapRect(origin: min, size: MKMapSize(width: max.x - min.x, height: max.y - min.y))
+        return BoundingBox(mapRect: rect)
+    }
+
+}
+
+public extension CollectionType where Generator.Element == CLLocationCoordinate2D {
+
+    /// Computes the BoundingBox of the coordinate list in O(n) time.
+    var boundingBox: BoundingBox {
+        guard let first = first else {
+            return BoundingBox(mapRect: MKMapRect())
+        }
+
+        var min = first
+        var max = first
+
+        for coord in self {
+            if coord.latitude < min.latitude {
+                min.latitude = coord.latitude
+            }
+            if coord.latitude > min.latitude {
+                max.latitude = coord.latitude
+            }
+            if coord.longitude < min.longitude {
+                min.longitude = coord.longitude
+            }
+            if coord.longitude > max.longitude {
+                max.longitude = coord.longitude
+            }
+        }
+
+        return BoundingBox(minCoordinate: min, maxCoordinate: max)
+    }
+
+}

--- a/BentoMap/CollectionTypeExtensions.swift
+++ b/BentoMap/CollectionTypeExtensions.swift
@@ -26,7 +26,7 @@ public extension CollectionType where Generator.Element: MapPointProvider {
             if mapPoint.x < min.x {
                 min.x = mapPoint.x
             }
-            if mapPoint.x > mapPoint.x {
+            if mapPoint.x > max.x {
                 max.x = mapPoint.x
             }
             if mapPoint.y < min.y {
@@ -58,7 +58,7 @@ public extension CollectionType where Generator.Element == CLLocationCoordinate2
             if coord.latitude < min.latitude {
                 min.latitude = coord.latitude
             }
-            if coord.latitude > min.latitude {
+            if coord.latitude > max.latitude {
                 max.latitude = coord.latitude
             }
             if coord.longitude < min.longitude {

--- a/BentoMap/QuadTree.swift
+++ b/BentoMap/QuadTree.swift
@@ -18,7 +18,7 @@ public struct QuadTree<NodeData> {
     public let bucketCapacity: Int
     public var points = [QuadTreeNode<NodeData>]()
 
-    public init(boundingBox: BoundingBox, bucketCapacity: Int) {
+    public init(boundingBox: BoundingBox = .world, bucketCapacity: Int) {
         precondition(bucketCapacity > 0, "Bucket capacity must be greater than 0")
         self.boundingBox = boundingBox
         self.bucketCapacity = bucketCapacity
@@ -130,8 +130,10 @@ private extension QuadTree {
 }
 
 private extension MKMapRect {
+
     func createStep(stepSize: Int, edgeFunction: (MKMapRect -> Double),
                     roundingFunction: (Double -> Double)) -> Int {
         return Int(roundingFunction(edgeFunction(self))) - (Int(roundingFunction(edgeFunction(self))) % stepSize)
     }
+
 }

--- a/BentoMap/QuadTreeNode.swift
+++ b/BentoMap/QuadTreeNode.swift
@@ -11,8 +11,8 @@ import MapKit
 
 public struct QuadTreeNode<NodeData> {
 
-    public let mapPoint: MKMapPoint
-    public let content: NodeData
+    public var mapPoint: MKMapPoint
+    public var content: NodeData
 
     public init(mapPoint: MKMapPoint, content: NodeData) {
         self.mapPoint = mapPoint

--- a/BentoMap/QuadTreeNode.swift
+++ b/BentoMap/QuadTreeNode.swift
@@ -9,7 +9,19 @@
 import Foundation
 import MapKit
 
-public struct QuadTreeNode<NodeData> {
+public protocol MapPointProvider {
+
+    var mapPoint: MKMapPoint { get }
+
+}
+
+extension MKMapPoint: MapPointProvider {
+
+    public var mapPoint: MKMapPoint { return self }
+
+}
+
+public struct QuadTreeNode<NodeData>: MapPointProvider {
 
     public var mapPoint: MKMapPoint
     public var content: NodeData

--- a/BentoMapTests/BoundingBoxTests.swift
+++ b/BentoMapTests/BoundingBoxTests.swift
@@ -107,6 +107,34 @@ class BoundingBoxTests: XCTestCase {
         XCTAssert(MKMapRectEqualToRect(quadrants.southWest.mapRect, swRect))
         XCTAssert(MKMapRectEqualToRect(quadrants.southEast.mapRect, seRect))
     }
+
+    func testCollectionTypeExtensions() {
+        let points = [
+            MKMapPoint(x: 25.0, y: 10956.7),
+            MKMapPoint(x: 1894.5, y: 22897.5550),
+            MKMapPoint(x: 25278.445, y: 156.339),
+            MKMapPoint(x: 17603.8472, y: 2456.7),
+        ]
+
+        var boundingBox = points.boundingBox
+
+        XCTAssert(MKMapPointEqualToPoint(boundingBox.minPoint, MKMapPoint(x: 25.0, y: 156.339)))
+        XCTAssert(MKMapPointEqualToPoint(boundingBox.maxPoint, MKMapPoint(x: 25278.445, y: 22897.5550)))
+
+        let coords = [
+            CLLocationCoordinate2D(latitude: 34.6790, longitude: 28.2847),
+            CLLocationCoordinate2D(latitude: -34.6790, longitude: 88.1349),
+            CLLocationCoordinate2D(latitude: 61.9471, longitude: -14.1887),
+            CLLocationCoordinate2D(latitude: 1.2898, longitude: 42.4277),
+        ]
+
+        boundingBox = coords.boundingBox
+
+        XCTAssertEqualWithAccuracy(boundingBox.minCoordinate.latitude, -34.6790, accuracy: 1e-4)
+        XCTAssertEqualWithAccuracy(boundingBox.minCoordinate.longitude, -14.1887, accuracy: 1e-4)
+        XCTAssertEqualWithAccuracy(boundingBox.maxCoordinate.latitude, 61.9471, accuracy: 1e-4)
+        XCTAssertEqualWithAccuracy(boundingBox.maxCoordinate.longitude, 88.1349, accuracy: 1e-4)
+    }
 }
 
 private extension MKMapPoint {


### PR DESCRIPTION
- Added conveniences to collections of map points or CLLocationCoordinates for computing bounding boxes.

- Added default value to QuadTree bounding box initialization'

- Changed several `let`s to `var`s