### PR TITLE
Better Bounding Boxes

### DIFF
--- a/BentoMap/BoundingBox.swift
+++ b/BentoMap/BoundingBox.swift
@@ -58,6 +58,14 @@ public extension BoundingBox {
 
 extension BoundingBox {
 
+    var quadrants: QuadrantWrapper<BoundingBox> {
+        let (north, south) = mapRect.divide(percent: 0.5, edge: .MinYEdge)
+        let (northWest, northEast) = north.divide(percent: 0.5, edge: .MinXEdge)
+        let (southWest, southEast) = south.divide(percent: 0.5, edge: .MinXEdge)
+
+        return QuadrantWrapper(northWest: northWest, northEast: northEast, southWest: southWest, southEast: southEast).map(BoundingBox.init)
+    }
+
     func containsMapPoint(mapPoint: MKMapPoint) -> Bool {
         return MKMapRectContainsPoint(mapRect, mapPoint)
     }
@@ -66,12 +74,8 @@ extension BoundingBox {
         return MKMapRectIntersectsRect(mapRect, boundingBox.mapRect)
     }
 
-    var quadrants: QuadrantWrapper<BoundingBox> {
-        let (north, south) = mapRect.divide(percent: 0.5, edge: .MinYEdge)
-        let (northWest, northEast) = north.divide(percent: 0.5, edge: .MinXEdge)
-        let (southWest, southEast) = south.divide(percent: 0.5, edge: .MinXEdge)
-
-        return QuadrantWrapper(northWest: northWest, northEast: northEast, southWest: southWest, southEast: southEast).map(BoundingBox.init)
+    mutating func union(other: BoundingBox) {
+        mapRect = MKMapRectUnion(mapRect, other.mapRect)
     }
 
 }

--- a/BentoMap/CollectionTypeExtensions.swift
+++ b/BentoMap/CollectionTypeExtensions.swift
@@ -73,3 +73,11 @@ public extension CollectionType where Generator.Element == CLLocationCoordinate2
     }
 
 }
+
+public extension CollectionType where Generator.Element: MKAnnotation {
+
+    var boundingBo: BoundingBox {
+        return map({ $0.coordinate }).boundingBox
+    }
+
+}

--- a/BentoMap/CollectionTypeExtensions.swift
+++ b/BentoMap/CollectionTypeExtensions.swift
@@ -76,7 +76,7 @@ public extension CollectionType where Generator.Element == CLLocationCoordinate2
 
 public extension CollectionType where Generator.Element: MKAnnotation {
 
-    var boundingBo: BoundingBox {
+    var boundingBox: BoundingBox {
         return map({ $0.coordinate }).boundingBox
     }
 

--- a/BentoMap/QuadTree.swift
+++ b/BentoMap/QuadTree.swift
@@ -14,13 +14,13 @@ public struct QuadTree<NodeData> {
 
     var ordinalNodes: OrdinalNodes<NodeData>?
 
-    public let boundingBox: BoundingBox
+    public let bucketRegion: BoundingBox
     public let bucketCapacity: Int
     public var points = [QuadTreeNode<NodeData>]()
 
-    public init(boundingBox: BoundingBox = .world, bucketCapacity: Int) {
+    public init(bucketRegion: BoundingBox = .world, bucketCapacity: Int) {
         precondition(bucketCapacity > 0, "Bucket capacity must be greater than 0")
-        self.boundingBox = boundingBox
+        self.bucketRegion = bucketRegion
         self.bucketCapacity = bucketCapacity
     }
 
@@ -72,7 +72,7 @@ public extension QuadTree {
 
 
     public mutating func insertNode(node: QuadTreeNode<NodeData>) -> Bool {
-        guard boundingBox.containsMapPoint(node.mapPoint) else {
+        guard bucketRegion.containsMapPoint(node.mapPoint) else {
             return false
         }
 
@@ -96,8 +96,8 @@ public extension QuadTree {
 private extension QuadTree {
 
     mutating func subdivide() {
-        let trees = boundingBox.quadrants.map { quadrant in
-            QuadTree(boundingBox: quadrant, bucketCapacity: self.bucketCapacity)
+        let trees = bucketRegion.quadrants.map { quadrant in
+            QuadTree(bucketRegion: quadrant, bucketCapacity: self.bucketCapacity)
         }
 
         ordinalNodes = OrdinalNodes(northWest: trees.northWest,
@@ -109,7 +109,7 @@ private extension QuadTree {
     func nodesInRange(range: BoundingBox) -> [QuadTreeNode<NodeData>] {
         var nodes = [QuadTreeNode<NodeData>]()
 
-        guard boundingBox.intersectsBoundingBox(range) else {
+        guard bucketRegion.intersectsBoundingBox(range) else {
             return nodes
         }
 

--- a/BentoMap/QuadTree.swift
+++ b/BentoMap/QuadTree.swift
@@ -28,6 +28,20 @@ public struct QuadTree<NodeData> {
 
 public extension QuadTree {
 
+    /// Recursively computes the bounding box of the points in the quad tree in O(n) time.
+    public var boundingBox: BoundingBox {
+        var boundingBox = points.boundingBox
+
+        if let ordinals = ordinalNodes {
+            boundingBox.union(ordinals.northWest.boundingBox)
+            boundingBox.union(ordinals.northEast.boundingBox)
+            boundingBox.union(ordinals.southWest.boundingBox)
+            boundingBox.union(ordinals.southEast.boundingBox)
+        }
+
+        return boundingBox
+    }
+
     public func clusteredDataWithinMapRect(mapRect: MKMapRect, zoomScale: Double, cellSize: Double) -> [QuadTreeResult<NodeData>] {
 
         let scaleFactor: Double

--- a/BentoMapTests/QuadTreeTests.swift
+++ b/BentoMapTests/QuadTreeTests.swift
@@ -22,9 +22,9 @@ class QuadTreeTests: XCTestCase {
 
     func testQuadTreeInitialization() {
         let box = BoundingBox(mapRect: MKMapRectWorld)
-        let quadTree = QuadTree<Void>(boundingBox: box, bucketCapacity: 5)
+        let quadTree = QuadTree<Void>(bucketRegion: box, bucketCapacity: 5)
 
-        XCTAssert(MKMapRectEqualToRect(box.mapRect, quadTree.boundingBox.mapRect), "The bounding box should equal the initalized bounding box")
+        XCTAssert(MKMapRectEqualToRect(box.mapRect, quadTree.bucketRegion.mapRect), "The bounding box should equal the initalized bounding box")
         XCTAssert(quadTree.bucketCapacity == 5, "The bucket capacity passed in is the bucket capacity used")
         XCTAssertNil(quadTree.ordinalNodes, "The initalized nodes should be empty")
         XCTAssertTrue(quadTree.points.isEmpty, "The bucket of points should be empty")
@@ -46,7 +46,7 @@ class QuadTreeTests: XCTestCase {
     func testQuadTreeInsertion() {
 
         let boundingBox = BoundingBox(mapRect: MKMapRect(origin: MKMapPoint(), size: MKMapSize(width: 5000, height: 5000)))
-        var quadTree = QuadTree<Int>(boundingBox: boundingBox, bucketCapacity: 5)
+        var quadTree = QuadTree<Int>(bucketRegion: boundingBox, bucketCapacity: 5)
         var i = 0
         for x in 0.stride(to: 5000, by: 50) {
             for y in 0.stride(to: 5000, by: 50) {


### PR DESCRIPTION
- Renamed QuadTree.boundingBox -> bucketRegion for clarity
- Added QuadTree.boundingBox var that recursively computes the bounding box of all points in the quad tree rooted at the receiver

**NOTE:** These are breaking API changes.