### PR TITLE
Hotfix/#16 cluster bounds clipping points

### DIFF
--- a/BentoMap/QuadTree.swift
+++ b/BentoMap/QuadTree.swift
@@ -70,10 +70,20 @@ public extension QuadTree {
 
         let stepSize = CGFloat(1.0 / scaleFactor)
 
+        // Prevents divide by zero errors from cropping up if handed bad data
+        let cellClip: Int
+        if ceil(cellSize) == 0 {
+            cellClip = 1
+        }
+        else {
+            cellClip = Int(ceil(cellSize))
+        }
         let minX = root.minX
-        let maxX = root.maxX
+        // normalizes the cell grid to make sure the last column is added to the buckets
+        let maxX = ceil(root.maxX) + CGFloat(cellSize - Double(Int(root.maxX) % cellClip))
         let minY = root.minY
-        let maxY = root.maxY
+        // normalizes the cell grid to make sure the last row is added to the buckets
+        let maxY = ceil(root.maxY) + CGFloat(cellSize - Double(Int(root.maxY) % cellClip))
 
         var result = [QuadTreeResult<NodeData, Rect, Coordinate>]()
 

--- a/BentoMap/QuadTreeResult.swift
+++ b/BentoMap/QuadTreeResult.swift
@@ -50,7 +50,7 @@ public enum QuadTreeResult<NodeData, Rect: BentoRect, Coordinate: BentoCoordinat
                 minCoordinate.x = min(minCoordinate.coordX, node.originCoordinate.coordX)
                 minCoordinate.y = min(minCoordinate.coordY, node.originCoordinate.coordY)
                 maxCoordinate.x = max(maxCoordinate.coordX, node.originCoordinate.coordX)
-                maxCoordinate.y = max(maxCoordinate.coordX, node.originCoordinate.coordY)
+                maxCoordinate.y = max(maxCoordinate.coordY, node.originCoordinate.coordY)
             }
             origin = Coordinate(coordX: minCoordinate.coordX, coordY: minCoordinate.coordY)
             // slightly pad the size to make sure all nodes are contained

--- a/BentoMap/QuadTreeResult.swift
+++ b/BentoMap/QuadTreeResult.swift
@@ -45,7 +45,7 @@ public enum QuadTreeResult<NodeData, Rect: BentoRect, Coordinate: BentoCoordinat
             size = CGSize()
         case let .multiple(nodes: nodes):
             var minCoordinate = CGPoint(x: CGFloat.greatestFiniteMagnitude, y: CGFloat.greatestFiniteMagnitude)
-            var maxCoordinate = CGPoint(x: CGFloat.leastNormalMagnitude, y: CGFloat.leastNormalMagnitude)
+            var maxCoordinate = CGPoint(x: -CGFloat.greatestFiniteMagnitude, y: -CGFloat.greatestFiniteMagnitude)
             for node in nodes {
                 minCoordinate.x = min(minCoordinate.coordX, node.originCoordinate.coordX)
                 minCoordinate.y = min(minCoordinate.coordY, node.originCoordinate.coordY)

--- a/BentoMapExample/App/MapKitViewController.swift
+++ b/BentoMapExample/App/MapKitViewController.swift
@@ -14,7 +14,7 @@ final class MapKitViewController: UIViewController {
 
     // Used to make sure the map is nicely padded on the edges, and visible annotations
     // aren't hidden under the navigation bar
-    static let mapInsets =  UIEdgeInsets(top: 80, left: 20, bottom: 20, right: 20)
+    static let mapInsets =  UIEdgeInsets(top: 100, left: 40, bottom: 40, right: 40)
 
     let mapData = QuadTree<Int, MKMapRect, CLLocationCoordinate2D>.sampleData
 


### PR DESCRIPTION
- wrote test to verify problem in lookup code
- normalizes the `quadTree.clusteredDataWithinMapRect(_,zoomScale:, cellSize:)` query to  include the last row / columns
- Increased edge padding in example to improve aesthetics
- Fixes #16